### PR TITLE
bugfix: social login for web

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,25 @@
+# Mode
 ENV=development
+
+# Social Login Secret Keys 
+## 1.Kakao
+NATIVE_APP_KEY
+JAVASCRIPT_APP_KEY
+KAKAO_CLIENT_ID
+
+## 2.Naver
+NAVER_CLIENT_ID
+NAVER_CLIENT_SECRET
+
+## 3.Apple
+APPLE_CLIENT_ID
+
+## Redirect url
+SOCIAL_REDIRECT_URL
+
+# Front URL
+FRONT_URL
+
+# Backends URL
+BASE_URL
+MOA_DJANGO_URL

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -120,6 +120,15 @@
             android:name="com.naver.sdk.clientName"
             android:value="@string/client_name" />
 
+        <!--flutter web auth 설정-->
+        <activity android:name="com.linusu.flutter_web_auth.CallbackActivity" android:exported="true">
+            <intent-filter android:label="flutter_web_auth">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="moaapp" />
+            </intent-filter>
+        </activity>
 
     </application>
 </manifest>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:moa_app/utils/config.dart';
 import 'package:moa_app/utils/router_provider.dart';
 import 'package:moa_app/utils/themes.dart';
 import 'package:moa_app/utils/tools.dart';
+import 'package:url_strategy/url_strategy.dart';
 
 class Logger extends ProviderObserver {
   @override
@@ -42,6 +43,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 }
 
 void main() async {
+  setPathUrlStrategy();
   var widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   await SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);

--- a/lib/navigations/main_bottom_tab.dart
+++ b/lib/navigations/main_bottom_tab.dart
@@ -1,10 +1,9 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:moa_app/constants/color_constants.dart';
 import 'package:moa_app/constants/file_constants.dart';
+import 'package:moa_app/utils/my_platform.dart';
 import 'package:moa_app/utils/router_provider.dart';
 
 enum ScreenType { social, generalMeetings }
@@ -79,7 +78,7 @@ class MainBottomTab extends HookWidget {
             notchMargin: 5,
             padding: EdgeInsets.only(
               top: 10,
-              bottom: Platform.isAndroid ? 10 : 0,
+              bottom: MyPlatform().isAndroid ? 10 : 0,
             ),
             child: Row(
               mainAxisSize: MainAxisSize.max,

--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -12,12 +12,35 @@ import 'package:moa_app/utils/logger.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:uuid/uuid.dart';
 
+
+class AuthDto {
+  // 임시로Moa back-end 로 보내기 위한 데이터를 관리하는 객체
+  // 성공, 실패에 대한 응답을 담고 있다.
+  AuthDto.fail(): isSuccess=false;
+
+  AuthDto.success({
+    required String this.id,
+    required String this.email,
+    required String this.token,
+    required String this.platform,
+  }): isSuccess=true;
+
+  String? id;
+  String? email;
+  String? token;
+  String? platform;
+  final bool isSuccess;
+
+}
+
+
 abstract class IAuthRepository {
   Future<void> googleLogin();
   Future<void> kakaoLogin();
   Future<void> naverLogin();
   Future<void> appleLogin();
 }
+
 
 class AuthRepository implements IAuthRepository {
   const AuthRepository._();
@@ -26,229 +49,260 @@ class AuthRepository implements IAuthRepository {
   @override
   Future<void> googleLogin() async {
     late GoogleSignInAccount? user;
-    var googleSignIn = GoogleSignIn();
+    var googleSignIn = GoogleSignIn(
+        signInOption: SignInOption.standard,
+        clientId: Config().googleClientId,
+
+    );
 
     if (kIsWeb) {
+      // TODO: signIn 이 WEB에서 처음에 안되서 다시 로그인 시도 해야 로그인 되는 현상이 있음
+      // 이거 문제가 뭔지 모르겠음...
       user = await googleSignIn.signInSilently();
       user ??= await googleSignIn.signIn();
     } else {
       user = await googleSignIn.signIn();
     }
 
-    if (user != null) {
-      var token = await user.authentication;
-      var res = await dio.post(
-        '/api/v1/user/oauth',
-        data: {
-          'platform': 'google',
-          'id': user.id,
-          'email': user.email,
-        },
-        options: Options(
-          headers: {'oauth-token': token.idToken},
-        ),
-      );
+    if (user == null) { return ; }
 
-      if (res.data['access_token'].isNotEmpty) {
-        await TokenRepository.instance
-            .setToken(token: res.data['access_token']);
-      }
-    }
+    var token = await user.authentication;
+
+    AuthDto authDto = token.idToken != null ?
+      AuthDto.success(
+        platform: 'google',
+        id: user.id,
+        email: user.email,
+        token: token.idToken!,):
+      AuthDto.fail();
+
+      await _loginAndSetTokenWith(authDto);
   }
 
   @override
   Future<void> kakaoLogin() async {
 
-    late String? token;
-    if (kIsWeb) {
+    AuthDto authDto = kIsWeb ?
+      await _kakaoLoginWeb():
+      await _kakaoLoginMobile();
 
-      // Kakao web authentication
-      var respAuth = await FlutterWebAuth.authenticate(
-        url: Uri.https('kauth.kakao.com','oauth/authorize', {
-          'client_id': Config().kakaoClientId,
-          'redirect_uri': Config().socialRedirectUrl,
-          'response_type': 'code',
-          'state': const Uuid().v4()
-        }).toString(),
-        callbackUrlScheme: 'moaapp',
-      );
+    if (authDto.isSuccess){
+      await _loginAndSetTokenWith(authDto);
+    }
+  }
 
-      // Handling Authentication Exception
-      String? authCode = Uri.parse(respAuth).queryParameters['code'];
-      if (authCode == null){
-        String resp = Uri.parse(respAuth).toString();
-        throw 'Fail authentication with kakao\n- $resp';
-      }
+  Future<AuthDto> _kakaoLoginWeb() async {
 
-      // Request Token
-      var respToken = await Dio().post(
-        'https://kauth.kakao.com/oauth/token',
-        data: {
-          'grant_type': 'authorization_code',
-          'client_id': Config().kakaoClientId,
-          'redirect_uri': Config().socialRedirectUrl,
-          'code': authCode,
+    // Kakao web authentication
+    var respAuth = await FlutterWebAuth.authenticate(
+      url: Uri.https('kauth.kakao.com','oauth/authorize', {
+        'client_id': Config().kakaoClientId,
+        'redirect_uri': Config().socialRedirectUrl,
+        'response_type': 'code',
+        'state': const Uuid().v4()
+      }).toString(),
+      callbackUrlScheme: 'moaapp',
+    );
+
+    // Handling Authentication Exception
+    String? authCode = Uri.parse(respAuth).queryParameters['code'];
+    if (authCode == null){
+      String resp = Uri.parse(respAuth).toString();
+      throw 'Fail authentication with kakao\n- $resp';
+    }
+
+    // Request Token
+    var respToken = await Dio().post(
+      'https://kauth.kakao.com/oauth/token',
+      data: {
+        'grant_type': 'authorization_code',
+        'client_id': Config().kakaoClientId,
+        'redirect_uri': Config().socialRedirectUrl,
+        'code': authCode,
+      },
+      options: Options(
+        headers: {
+          HttpHeaders.contentTypeHeader:
+          'application/x-www-form-urlencoded;charset=utf-8'
         },
-        options: Options(
-          headers: {
-            HttpHeaders.contentTypeHeader: 'application/x-www-form-urlencoded;charset=utf-8'
-          },
-        ),
-      );
+      ),
+    );
 
-      token = respToken.data['access_token'];
-
-    } else {
-      var isInstalled = await isKakaoTalkInstalled();
-      OAuthToken oauthToken = isInstalled
-          ? await UserApi.instance.loginWithKakaoTalk()
-          : await UserApi.instance.loginWithKakaoAccount();
-      token = oauthToken.accessToken;
+    if (respToken.statusCode != 200) {
+      return AuthDto.fail();
     }
 
-    if (token != null){
-      var response = await Dio().get(
-        'https://kapi.kakao.com/v2/user/me',
-        options: Options(
-          headers: {
-            HttpHeaders.authorizationHeader: 'Bearer $token'
-          },
-        ),
+    return await _kakaoRequestUserInfo(
+        token: respToken.data['access_token']
+    );
+  }
+
+  Future<AuthDto> _kakaoLoginMobile() async {
+
+    var isInstalled = await isKakaoTalkInstalled();
+
+    OAuthToken oauthToken = isInstalled
+        ? await UserApi.instance.loginWithKakaoTalk()
+        : await UserApi.instance.loginWithKakaoAccount();
+
+    return await _kakaoRequestUserInfo(
+        token: oauthToken.accessToken
+    );
+  }
+
+  Future<AuthDto> _kakaoRequestUserInfo({
+    required String token }) async {
+
+    var response = await Dio().get(
+      'https://kapi.kakao.com/v2/user/me',
+      options: Options(
+        headers: {
+          HttpHeaders.authorizationHeader: 'Bearer $token'
+        },
+      ),
+    );
+
+    if (response.data.isNotEmpty) {
+      return AuthDto.success(
+          id: response.data['id'].toString(),
+          email: response.data['kakao_account']['email'],
+          token: token,
+          platform: 'kakao',
       );
-
-      if (response.data.isNotEmpty) {
-        var res = await dio.post(
-          '/api/v1/user/oauth',
-          data: {
-            'platform': 'kakao',
-            'id': response.data['id'],
-            'email': response.data['kakao_account']['email'],
-          },
-          options: Options(
-            headers: {
-              'oauth-token': token,
-            },
-          ),
-        );
-
-        if (res.data['access_token'].isNotEmpty) {
-          await TokenRepository.instance
-              .setToken(token: res.data['access_token']);
-        }
-      }
     }
+    return AuthDto.fail();
   }
 
   @override
   Future<void> naverLogin() async {
+    AuthDto authDto = kIsWeb ?
+      await _naverLoginWeb():
+      await _naverLoginMobile();
+
+    await _loginAndSetTokenWith(authDto);
+  }
+
+  Future<AuthDto> _naverLoginWeb() async {
+    // Present the dialog to the user
+    var resultAuth = await FlutterWebAuth.authenticate(
+      url: Uri.https('nid.naver.com', 'oauth2.0/authorize', {
+        'client_id': Config().naverClientId,
+        'redirect_uri': Config().socialRedirectUrl,
+        'response_type': 'code',
+        'state': const Uuid().v4()
+      }).toString(),
+      callbackUrlScheme: 'moaapp',
+    );
+    // Extract code from resulting url
+    // result = http://localhost:8080/sign-in?code=dXi4LtnBGvkWwupyr7&state=test
+    var code = Uri
+        .parse(resultAuth)
+        .queryParameters['code'];
+
+    var resToken = await Dio().get(
+      '${Config().moaDjangoUrl}/proxy_auth/naver_token',
+      queryParameters: {
+        'client_id': Config().naverClientId,
+        'client_secret': Config().naverClientSecret,
+        'grant_type': 'authorization_code',
+        'code': code,
+        'state': const Uuid().v4(),
+      },
+    );
+
+    if (resToken.statusCode != 200) {
+      return AuthDto.fail();
+    }
+
+    return AuthDto.success(
+        id: resToken.data['id'],
+        email: resToken.data['email'],
+        token: resToken.data['access_token'],
+        platform: 'naver',
+    );
+  }
+
+  Future<AuthDto> _naverLoginMobile() async {
     late NaverAccessToken token;
     late NaverLoginResult user;
-    if (kIsWeb) {
-      // Web NAVER social login
 
-      // Present the dialog to the user
-      var resultAuth = await FlutterWebAuth.authenticate(
-        url: Uri.https('nid.naver.com','oauth2.0/authorize', {
-          'client_id': Config().naverClientId,
-          'redirect_uri': Config().socialRedirectUrl,
-          'response_type': 'code',
-          'state': const Uuid().v4()
-        }).toString(),
-        callbackUrlScheme: 'moaapp',
-      );
-      // Extract code from resulting url
-      // result = http://localhost:8080/sign-in?code=dXi4LtnBGvkWwupyr7&state=test
-      var code = Uri.parse(resultAuth).queryParameters['code'];
+    // Non web Naver login option
+    user = await FlutterNaverLogin.logIn();
+    token = await FlutterNaverLogin.currentAccessToken;
 
-      var resToken = await Dio().get(
-          '${Config().moaDjangoUrl}/proxy_auth/naver_token',
-          queryParameters: {
-            'client_id': Config().naverClientId,
-            'client_secret': Config().naverClientSecret,
-            'grant_type': 'authorization_code',
-            'code': code,
-            'state': const Uuid().v4(),
-          },
-      );
-
-      if (resToken.statusCode==200) {
-        var res = await dio.post(
-          '/api/v1/user/oauth',
-          data: {
-            'platform': 'naver',
-            'id': resToken.data['id'],
-            'email': resToken.data['email'],
-          },
-          options: Options(
-            headers: {'oauth-token': resToken.data['access_token']},
-          ),
-        );
-
-        if (res.data['access_token'].isNotEmpty) {
-          await TokenRepository.instance
-              .setToken(token: res.data['access_token']);
-        }
-      }
-
-    } else {
-      // Non web Naver login option
-      user = await FlutterNaverLogin.logIn();
-      token = await FlutterNaverLogin.currentAccessToken;
-      if (user.status != NaverLoginStatus.loggedIn) {
-        return;
-      }
-
-      if (token.accessToken.isNotEmpty) {
-        var res = await dio.post(
-          '/api/v1/user/oauth',
-          data: {
-            'platform': 'naver',
-            'id': user.account.id,
-            'email': user.account.email,
-          },
-          options: Options(
-            headers: {'oauth-token': token.accessToken},
-          ),
-        );
-
-        if (res.data['access_token'].isNotEmpty) {
-          await TokenRepository.instance
-              .setToken(token: res.data['access_token']);
-        }
-      }
+    if (user.status != NaverLoginStatus.loggedIn) {
+      return AuthDto.fail();
     }
+
+    return AuthDto.success(
+        id: user.account.id,
+        email: user.account.email,
+        token: token.accessToken,
+        platform: 'naver',
+    );
   }
 
   @override
   Future<void> appleLogin() async {
     var credential = await SignInWithApple.getAppleIDCredential(
-      scopes: [
-        AppleIDAuthorizationScopes.email,
-        AppleIDAuthorizationScopes.fullName,
-      ],
-      webAuthenticationOptions: kIsWeb? WebAuthenticationOptions(
-        clientId: 'asd',
-        redirectUri: Uri.parse(Config().socialRedirectUrl)
-      ) : null
+        scopes: [
+          AppleIDAuthorizationScopes.email,
+          AppleIDAuthorizationScopes.fullName,
+        ],
+        // TODO: Apple login은 clientId가 없어 아직 테스트 못해봄
+        webAuthenticationOptions: kIsWeb ? WebAuthenticationOptions(
+            clientId: Config().appleClientId,
+            redirectUri: Uri.parse(Config().socialRedirectUrl)
+        ) : null
     );
 
     if (credential.identityToken != null && credential.userIdentifier != null) {
-      var res = await dio.post(
-        '/api/v1/user/oauth',
-        data: {
-          'platform': 'apple',
-          'id': credential.userIdentifier,
-          'email': credential.email,
-        },
-        options: Options(
-          headers: {'oauth-token': credential.identityToken},
-        ),
-      );
-
-      if (res.data['access_token'].isNotEmpty) {
-        await TokenRepository.instance
-            .setToken(token: res.data['access_token']);
-      }
+      await _loginAndSetTokenWith(AuthDto.success(
+        id: credential.userIdentifier!,
+        email: credential.email!,
+        token: credential.identityToken!,
+        platform: 'apple',
+      ));
     }
   }
+
+  Future<void> _loginAndSetTokenWith(AuthDto authDto) async {
+    if(!authDto.isSuccess) {
+      // TODO: 로그인에 실패 예외처리 하기, 메세지를 띄운다든지 등등
+      logger.d('Login Fail');
+      return ;
+    }
+
+    var res = await dio.post(
+      '/api/v1/user/oauth',
+      data: {
+        'platform': authDto.platform,
+        'id': authDto.id,
+        'email': authDto.email,
+      },
+      options: Options(
+        headers: {'oauth-token': authDto.token},
+      ),
+    );
+
+    if (res.statusCode != 200) {
+      // TODO: 우리 백엔드 쪽, 처리 실패 관련 예외처리 하기
+      logger.d('Moa-Spring Error - $res.statusCode\n$res.data');
+      return ;
+    }
+
+    await TokenRepository.instance
+        .setToken(token: res.data['access_token']);
+
+    // 로그인 성공
+    logger.d(
+        'login success\n'
+        'platform: ${authDto.platform}\n'
+        'id      : ${authDto.id}\n'
+        'email   : ${authDto.email}\n'
+        'token   : ${authDto.token}\n'
+    );
+  }
+
+
 }

--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -268,9 +268,7 @@ class AuthRepository implements IAuthRepository {
 
   Future<void> _loginAndSetTokenWith(AuthDto authDto) async {
     if(!authDto.isSuccess) {
-      // TODO: 로그인에 실패 예외처리 하기, 메세지를 띄운다든지 등등
-      logger.d('Login Fail');
-      return ;
+      throw 'Login failed with oauth provider';
     }
 
     var res = await dio.post(
@@ -286,9 +284,7 @@ class AuthRepository implements IAuthRepository {
     );
 
     if (res.statusCode != 200) {
-      // TODO: 우리 백엔드 쪽, 처리 실패 관련 예외처리 하기
-      logger.d('Moa-Spring Error - $res.statusCode\n$res.data');
-      return ;
+      throw 'Login failed with moa-spring with ${res.statusCode} cdoe';
     }
 
     await TokenRepository.instance

--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -29,6 +29,7 @@ class AuthRepository implements IAuthRepository {
 
     if (kIsWeb) {
       user = await googleSignIn.signInSilently();
+      user ??= await googleSignIn.signIn();
     } else {
       user = await googleSignIn.signIn();
     }

--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -1,13 +1,15 @@
 import 'dart:io';
-
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_naver_login/flutter_naver_login.dart';
+import 'package:flutter_web_auth/flutter_web_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:moa_app/repositories/token_repository.dart';
 import 'package:moa_app/utils/api.dart';
+import 'package:moa_app/utils/logger.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+import 'package:uuid/uuid.dart';
 
 abstract class IAuthRepository {
   Future<void> googleLogin();
@@ -102,35 +104,85 @@ class AuthRepository implements IAuthRepository {
     late NaverAccessToken token;
     late NaverLoginResult user;
     if (kIsWeb) {
-      Dio naverDio = Dio();
-      // todo front에서 요청시 cors 에러 back에서 처리하고 응답 받아야할듯
-      await naverDio.get(
-        'https://nid.naver.com/oauth2.0/authorize?client_id=K10uUCEMBAnAY0ZtJMeo&redirect_uri=http://localhost:8080&response_type=code&state=test',
+      // Web NAVER social login
+
+
+      // Present the dialog to the user
+      var resultAuth = await FlutterWebAuth.authenticate(
+        url: Uri.https('nid.naver.com','oauth2.0/authorize', {
+          'client_id': 'K10uUCEMBAnAY0ZtJMeo',
+          // TODO: 배포 시, 도메인 설정 해줘야 함
+          'redirect_uri': 'http://localhost:8080/sign-in',
+          'response_type': 'code',
+          'state': const Uuid().v4()
+        }).toString(),
+        callbackUrlScheme: 'moaapp',
       );
+      // Extract code from resulting url
+      // result = http://localhost:8080/sign-in?code=dXi4LtnBGvkWwupyr7&state=test
+      var code = Uri.parse(resultAuth).queryParameters['code'];
+
+
+
+      logger.d(code);
+      var resToken = await Dio().get(
+          'http://moa.gomj.kr:6001/proxy_auth/naver_token',
+          queryParameters: {
+            // TODO: 이거 숨겨야 함
+            'client_id': 'K10uUCEMBAnAY0ZtJMeo',
+            'client_secret': 'qtCW1qORKI',
+            'grant_type': 'authorization_code',
+            'code': code,
+            'state': const Uuid().v4(),
+          },
+      );
+
+      logger.d(resToken.data);
+
+      if (resToken.statusCode==200) {
+        var res = await dio.post(
+          '/api/v1/user/oauth',
+          data: {
+            'platform': 'naver',
+            'id': resToken.data['id'],
+            'email': resToken.data['email'],
+          },
+          options: Options(
+            headers: {'oauth-token': resToken.data['access_token']},
+          ),
+        );
+
+        if (res.data['access_token'].isNotEmpty) {
+          await TokenRepository.instance
+              .setToken(token: res.data['access_token']);
+        }
+      }
+
     } else {
+      // Non web Naver login option
       user = await FlutterNaverLogin.logIn();
       token = await FlutterNaverLogin.currentAccessToken;
       if (user.status != NaverLoginStatus.loggedIn) {
         return;
       }
-    }
 
-    if (token.accessToken.isNotEmpty) {
-      var res = await dio.post(
-        '/api/v1/user/oauth',
-        data: {
-          'platform': 'naver',
-          'id': user.account.id,
-          'email': user.account.email,
-        },
-        options: Options(
-          headers: {'oauth-token': token.accessToken},
-        ),
-      );
+      if (token.accessToken.isNotEmpty) {
+        var res = await dio.post(
+          '/api/v1/user/oauth',
+          data: {
+            'platform': 'naver',
+            'id': user.account.id,
+            'email': user.account.email,
+          },
+          options: Options(
+            headers: {'oauth-token': token.accessToken},
+          ),
+        );
 
-      if (res.data['access_token'].isNotEmpty) {
-        await TokenRepository.instance
-            .setToken(token: res.data['access_token']);
+        if (res.data['access_token'].isNotEmpty) {
+          await TokenRepository.instance
+              .setToken(token: res.data['access_token']);
+        }
       }
     }
   }

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -34,8 +34,9 @@ class SignIn extends HookConsumerWidget {
         if (context.mounted) {
           context.go(GoRoutes.home.fullPath);
         }
-      } catch (e) {
+      } catch (e, traceback) {
         logger.d(e);
+        logger.d(traceback);
         snackbar.alert(context,
             kDebugMode ? e.toString() : '회원가입 중 에러가 발생했습니다. 관리자에게 문의해주세요.');
       } finally {

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -150,7 +150,7 @@ class SignIn extends HookConsumerWidget {
                           ),
                         ),
                       ),
-                      (!kIsWeb && Platform.isIOS)
+                      (kIsWeb || Platform.isIOS)
                           ? GestureDetector(
                               onTap: () {
                                 handleLogin(AuthRepository.instance.appleLogin);

--- a/lib/utils/config.dart
+++ b/lib/utils/config.dart
@@ -9,16 +9,19 @@ class Config {
   static final Config _singleton = Config._internal();
 
   // Social Login Secret Keys
-  // 1. 카카오
+  // 1. 구글
+  String get googleClientId => env('GOOGLE_CLIENT_ID');
+  String get googleClientSecret => env('GOOGLE_CLIENT_SECRET');
+  // 2. 카카오
   String get nativeAppKey => env('NATIVE_APP_KEY');
   String get javaScriptAppKey => env('JAVASCRIPT_APP_KEY');
   String get kakaoClientId => env('KAKAO_CLIENT_ID');
-  // 2. 네이버
+  // 3. 네이버
   String get naverClientId => env('NAVER_CLIENT_ID');
   String get naverClientSecret => env('NAVER_CLIENT_SECRET');
-  // 3. 애플
+  // 4. 애플
   String get appleClientId => env('APPLE_CLIENT_ID');
-  // 4. FCM
+  // 5. FCM
   String get webFcmKey => env('WEB_FCM_KEY');
   // 웹 로그인 시, Redirect 할 URL
   String get socialRedirectUrl => env('SOCIAL_REDIRECT_URL');

--- a/lib/utils/config.dart
+++ b/lib/utils/config.dart
@@ -8,8 +8,26 @@ class Config {
   Config._internal();
   static final Config _singleton = Config._internal();
 
+  // Social Login Secret Keys
+  // 1. 카카오
   String get nativeAppKey => env('NATIVE_APP_KEY');
   String get javaScriptAppKey => env('JAVASCRIPT_APP_KEY');
-  String get baseUrl => env('BASE_URL');
+  String get kakaoClientId => env('KAKAO_CLIENT_ID');
+  // 2. 네이버
+  String get naverClientId => env('NAVER_CLIENT_ID');
+  String get naverClientSecret => env('NAVER_CLIENT_SECRET');
+  // 3. 애플
+  String get appleClientId => env('APPLE_CLIENT_ID');
+  // 4. FCM
   String get webFcmKey => env('WEB_FCM_KEY');
+  // 웹 로그인 시, Redirect 할 URL
+  String get socialRedirectUrl => env('SOCIAL_REDIRECT_URL');
+
+  // Front URL
+  String get frontUrl => env('FRONT_URL');
+  // Backends URL
+  // Moa-Spring
+  String get baseUrl => env('BASE_URL');
+  // Moa-Django
+  String get moaDjangoUrl => env('MOA_DJANGO_URL');
 }

--- a/lib/utils/my_platform.dart
+++ b/lib/utils/my_platform.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/foundation.dart';
+
+
+class MyPlatform {
+  factory MyPlatform() {
+    return _singleton;
+  }
+
+  MyPlatform._internal();
+  static final MyPlatform _singleton = MyPlatform._internal();
+
+  bool get isAndroid => defaultTargetPlatform == TargetPlatform.android;
+  bool get isIos     => defaultTargetPlatform == TargetPlatform.iOS;
+  bool get isLinux   => defaultTargetPlatform == TargetPlatform.linux;
+  bool get isMacOS   => defaultTargetPlatform == TargetPlatform.macOS;
+  bool get isWindows => defaultTargetPlatform == TargetPlatform.windows;
+
+  bool get isWeb     => kIsWeb;
+  bool get isDesktop => isWindows || isMacOS;
+  bool get isMobile  => isAndroid || isIos;
+}

--- a/lib/utils/router_provider.dart
+++ b/lib/utils/router_provider.dart
@@ -80,7 +80,6 @@ final routeProvider = Provider((ref) {
           /// 알람 권한 요청
           if (!kIsWeb && context.mounted) {
             FcmService.instance.requestIosFirebaseMessaging();
-
             FcmService.instance.foregroundMessageHandler();
             FcmService.instance.foregroundClickHandler(context);
             FcmService.instance.setupInteractedMessage(context);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -605,6 +605,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_auth:
+    dependency: "direct main"
+    description:
+      name: flutter_web_auth
+      sha256: a69fa8f43b9e4d86ac72176bf747b735e7b977dd7cf215076d95b87cb05affdd
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -1505,8 +1513,16 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  url_strategy:
+    dependency: "direct main"
+    description:
+      name: url_strategy
+      sha256: "42b68b42a9864c4d710401add17ad06e28f1c1d5500c93b98c431f6b0ea4ab87"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   riverpod_lint: ^1.3.1
   flutter_native_splash: ^2.2.16
   # OAuth related packages
+  flutter_web_auth: ^0.5.0
   google_sign_in: ^6.1.0
   flutter_naver_login: ^1.8.0
   kakao_flutter_sdk_user: ^1.4.3
@@ -69,6 +70,9 @@ dependencies:
   
   extended_nested_scroll_view: ^6.1.0
   loading_more_list: ^5.0.3
+
+  uuid: ^3.0.7
+  url_strategy: ^0.2.0
 
 dependency_overrides:
   intl: ^0.17.0-nullsafety.2

--- a/web/index.html
+++ b/web/index.html
@@ -31,7 +31,10 @@
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <meta name="google-signin-client_id" content="286463462021-ubqeqqth4lmmohjbgqi8lo017rs3r7ph.apps.googleusercontent.com">
 
-  <!-- flutter web auth -->
+  <!-- apple login -->
+  <script type="text/javascript" src="https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js"></script>
+
+<!--   flutter web auth -->
   <script>
     window.opener.postMessage({
       'flutter-web-auth': window.location.href

--- a/web/index.html
+++ b/web/index.html
@@ -31,6 +31,14 @@
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <meta name="google-signin-client_id" content="286463462021-ubqeqqth4lmmohjbgqi8lo017rs3r7ph.apps.googleusercontent.com">
 
+  <!-- flutter web auth -->
+  <script>
+    window.opener.postMessage({
+      'flutter-web-auth': window.location.href
+    }, window.location.origin);
+    window.close();
+  </script>
+
   <title>moa_app</title>
   <link rel="manifest" href="manifest.json">
   


### PR DESCRIPTION
## 설명
### 1. 로그인 관련 이슈
- Web에서 Naver, Kakao등 로그인이 잘 되지 않는 이슈를 해결하였습니다. Closes #13 
- Naver의 경우 별도의 Python django proxy server를 만들어 token 받아오는 처리를 대신 해줄 수 있도록 설정 하였습니다.
- https://github.com/paulracooni/Moa-Django

### 2. Web 호환성 이슈
- Flutter web에서는 Platform 사용이 안되어, 비슷한 MyPlatform을 만들어 해당 코드를 일부 수정했습니다.
- Flutter web에서는 Apple login이 보이는 것이 맞는것 같아 일단은 버튼을 열어 두었습니다. (논의 필요)

### 3. .env 관련 민감한 정보 추가
- auth_repository.dart 파일에 민감한 정보가 많아 .env 파일에 전부 숨겼습니다.
- 따라서, .env 파일이 많이 수정 되었습니다.
- client secret 같은것들.
- .env는 슬랙을 통해 공유 드리겠습니다.

## 이슈
- google login의 경우, 첫번째 로그인 때, 로그인 실패하다가 두번째 로그인 하면 로그인이 되는 이슈가 있는데.
아직 원인을 모르겠습니다....
- apple login 할려면 client secret을 알아야 하는데 어디서 확인하는지 모르겠어요.