### PR TITLE
ci: Containerize moa-web with docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+#Stage 1 - Install dependencies and build the app
+FROM debian:latest AS build-env
+
+# Install flutter dependencies
+RUN apt-get update
+RUN apt-get install -y curl git wget unzip libgconf-2-4 gdb libstdc++6 libglu1-mesa fonts-droid-fallback lib32stdc++6 python3
+RUN apt-get clean
+
+# Clone the flutter repo
+RUN git clone https://github.com/flutter/flutter.git /usr/local/flutter
+
+# Set flutter path
+# RUN /usr/local/flutter/bin/flutter doctor -v
+ENV PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:${PATH}"
+
+# Run flutter doctor
+RUN flutter doctor -v
+# Enable flutter web
+RUN flutter channel master
+RUN flutter upgrade
+RUN flutter config --enable-web
+
+# Copy files to container and build
+RUN mkdir /app/
+COPY . /app/
+WORKDIR /app/
+RUN flutter build web
+
+# Stage 2 - Create the run-time image
+FROM nginx:1.21.1-alpine
+COPY --from=build-env /app/build/web /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN flutter config --enable-web
 RUN mkdir /app/
 COPY . /app/
 WORKDIR /app/
+RUN dart run build_runner build --delete-conflicting-outputs
 RUN flutter build web
 
 # Stage 2 - Create the run-time image

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,5 @@ RUN flutter build web
 
 # Stage 2 - Create the run-time image
 FROM nginx:1.21.1-alpine
+COPY --from=build-env /app/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build-env /app/build/web /usr/share/nginx/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,6 @@ services:
   moa-web:
     build: .
     ports:
-      - 8080:80
+      - 6002:80
     volumes:
       - ./:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+
+services:
+  moa-web:
+    build: .
+    ports:
+      - 6002:80
+    volumes:
+      - ./:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,6 @@ services:
   moa-web:
     build: .
     ports:
-      - 6002:80
+      - 8080:80
     volumes:
       - ./:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,6 @@ services:
   moa-web:
     build: .
     ports:
-      - 6002:80
+      - 80:80
     volumes:
       - ./:/app

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
+import 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:moa_app/firebase_options.dart';
@@ -16,7 +17,6 @@ import 'package:moa_app/utils/config.dart';
 import 'package:moa_app/utils/router_provider.dart';
 import 'package:moa_app/utils/themes.dart';
 import 'package:moa_app/utils/tools.dart';
-import 'package:url_strategy/url_strategy.dart';
 
 class Logger extends ProviderObserver {
   @override
@@ -43,7 +43,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 }
 
 void main() async {
-  setPathUrlStrategy();
+  usePathUrlStrategy();
   var widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   await SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,45 @@
+server {
+    listen 80 default_server;
+    # listen [::]:80 default_server;
+    server_name  _;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -614,7 +614,7 @@ packages:
     source: hosted
     version: "0.5.0"
   flutter_web_plugins:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1513,14 +1513,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
-  url_strategy:
-    dependency: "direct main"
-    description:
-      name: url_strategy
-      sha256: "42b68b42a9864c4d710401add17ad06e28f1c1d5500c93b98c431f6b0ea4ab87"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.0"
   uuid:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
   flutter_localizations:
     sdk: flutter
 
@@ -72,7 +74,6 @@ dependencies:
   loading_more_list: ^5.0.3
 
   uuid: ^3.0.7
-  url_strategy: ^0.2.0
   google_sign_in_web: ^0.12.0+2
 
 dependency_overrides:


### PR DESCRIPTION
## 설명

### 1. Docker-compose를 활용
- Moa-web을 배포할 수 있는 컨테이너를 만들었습니다.
- reference: https://github.com/edwardinubuntu/flutter-web-dockerfile/tree/master

### 2. Moa-web 서비스, NCP에 배포.
- Moa-web 테스트 서버 주소, http://moa.gomj.kr

## 이슈
- 막상 배포해 보니, 로그인이 잘 안됨.
- 아마 redirect_url 문제인 것 같음.