### PR TITLE
refactor: go_router 버전 업데이트 및 이슈 수정

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
-import 'package:flutter_web_plugins/url_strategy.dart';
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:moa_app/constants/app_constants.dart';
@@ -43,7 +43,6 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 }
 
 void main() async {
-  usePathUrlStrategy();
   var widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   await SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
@@ -58,6 +57,7 @@ void main() async {
   KakaoSdk.init(
       nativeAppKey: Config().nativeAppKey,
       javaScriptAppKey: Config().javaScriptAppKey);
+  usePathUrlStrategy();
   runApp(ProviderScope(observers: [Logger()], child: const MyApp()));
 }
 
@@ -75,7 +75,7 @@ class MyApp extends HookConsumerWidget {
       return null;
     }, [token.isLoading]);
 
-    if (token.isLoading) {
+    if (token.isLoading && !kIsWeb) {
       return const MaterialApp(
         home: Scaffold(body: SizedBox()),
       );

--- a/lib/models/folder_model.dart
+++ b/lib/models/folder_model.dart
@@ -6,7 +6,7 @@ part 'folder_model.g.dart';
 @freezed
 class FolderModel with _$FolderModel {
   const factory FolderModel({
-    required int id,
+    required String id,
     required String title,
     required String content,
   }) = _FolderModel;

--- a/lib/screens/home/content_view.dart
+++ b/lib/screens/home/content_view.dart
@@ -10,8 +10,8 @@ import 'package:moa_app/widgets/button.dart';
 import 'package:moa_app/widgets/moa_widgets/bottom_modal_item.dart';
 
 class ContentView extends HookWidget {
-  const ContentView({super.key, required this.contentId});
-  final int contentId;
+  const ContentView({super.key, required this.id});
+  final String id;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/home/folder_detail_view.dart
+++ b/lib/screens/home/folder_detail_view.dart
@@ -8,14 +8,14 @@ import 'package:moa_app/screens/home/widgets/type_header.dart';
 import 'package:moa_app/utils/general.dart';
 import 'package:moa_app/widgets/app_bar.dart';
 import 'package:moa_app/widgets/button.dart';
-import 'package:moa_app/widgets/dynamic_grid_list.dart';
 import 'package:moa_app/widgets/moa_widgets/bottom_modal_item.dart';
 import 'package:moa_app/widgets/moa_widgets/delete_content.dart';
+import 'package:moa_app/widgets/moa_widgets/dynamic_grid_list.dart';
 import 'package:moa_app/widgets/moa_widgets/edit_content.dart';
 
 class FolderDetailView extends HookWidget {
-  const FolderDetailView({super.key, required this.folderName});
-  final String folderName;
+  const FolderDetailView({super.key, required this.folderId});
+  final String folderId;
 
   @override
   Widget build(BuildContext context) {
@@ -43,7 +43,7 @@ class FolderDetailView extends HookWidget {
             // todo 폴더 수정 api 연동후 성공하면 아래 코드 실행 실패시 snackbar 경고
           },
           updatedContentName: updatedContentName,
-          contentName: folderName,
+          contentName: 'folderName',
         ),
         isContainer: false,
       );
@@ -55,7 +55,7 @@ class FolderDetailView extends HookWidget {
         context: context,
         isCloseButton: true,
         child: DeleteContent(
-          contentName: folderName,
+          contentName: 'folderName',
           type: ContentType.folder,
           onPressed: () {
             // todo 폴더 삭제 api 연동후 성공하면 아래 코드 실행 실패시 snackbar 경고
@@ -103,9 +103,9 @@ class FolderDetailView extends HookWidget {
     return Scaffold(
       appBar: AppBarBack(
         isBottomBorderDisplayed: false,
-        title: Text(
-          folderName,
-          style: const H2TextStyle(),
+        title: const Text(
+          'folderName',
+          style: H2TextStyle(),
         ),
         actions: [
           CircleIconButton(
@@ -128,6 +128,7 @@ class FolderDetailView extends HookWidget {
             const SizedBox(height: 5),
             Expanded(
               child: DynamicGridList(
+                // todo folder id 내려줘야함
                 pullToRefresh: pullToRefresh,
               ),
             ),

--- a/lib/screens/home/hashtag_detail_view.dart
+++ b/lib/screens/home/hashtag_detail_view.dart
@@ -8,9 +8,9 @@ import 'package:moa_app/screens/home/widgets/type_header.dart';
 import 'package:moa_app/utils/general.dart';
 import 'package:moa_app/widgets/app_bar.dart';
 import 'package:moa_app/widgets/button.dart';
-import 'package:moa_app/widgets/dynamic_grid_list.dart';
 import 'package:moa_app/widgets/moa_widgets/bottom_modal_item.dart';
 import 'package:moa_app/widgets/moa_widgets/delete_content.dart';
+import 'package:moa_app/widgets/moa_widgets/dynamic_grid_list.dart';
 import 'package:moa_app/widgets/moa_widgets/edit_content.dart';
 
 class HashtagDetailView extends HookWidget {

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -286,12 +286,12 @@ class FolderSource extends LoadingMoreBase<FolderModel> {
         clear();
       }
       for (int i = 0; i < 4; i++) {
-        add(const FolderModel(id: 0, title: 'title', content: 'content'));
+        add(const FolderModel(id: '0', title: 'title', content: 'content'));
       }
 
       add(
         const FolderModel(
-          id: 0,
+          id: '0',
           title: 'title',
           content: 'content',
         ),

--- a/lib/screens/home/tab_view/folder_tab_view.dart
+++ b/lib/screens/home/tab_view/folder_tab_view.dart
@@ -6,7 +6,6 @@ import 'package:loading_more_list/loading_more_list.dart';
 import 'package:moa_app/constants/app_constants.dart';
 import 'package:moa_app/constants/file_constants.dart';
 import 'package:moa_app/models/folder_model.dart';
-import 'package:moa_app/screens/home/folder_detail_view.dart';
 import 'package:moa_app/screens/home/home.dart';
 import 'package:moa_app/utils/general.dart';
 import 'package:moa_app/utils/router_provider.dart';
@@ -32,15 +31,10 @@ class FolderTabView extends HookWidget {
       );
     }
 
-    void goFolderDetailView(String title) {
-      // context.namedLocation(
-      //   GoRoutes.home.name + GoRoutes.folderDetail.name,
-      //   queryParameters: {'id': title},
-      // );
-
-      context.push(
-        '${GoRoutes.folderDetail.fullPath}/$title',
-        extra: FolderDetailView(folderName: title),
+    void goFolderDetailView(String folderId) {
+      context.go(
+        '${GoRoutes.folder.fullPath}/$folderId',
+        // '/folder/$folderId',
       );
     }
 
@@ -86,7 +80,7 @@ class FolderTabView extends HookWidget {
                   : FolderList(
                       folder: item,
                       folderColor: folderColors[index % 4],
-                      onPress: () => goFolderDetailView(item.title),
+                      onPress: () => goFolderDetailView(item.id),
                     );
             },
           ),

--- a/lib/screens/home/tab_view/hashtag_tab_view.dart
+++ b/lib/screens/home/tab_view/hashtag_tab_view.dart
@@ -6,8 +6,6 @@ import 'package:loading_more_list/loading_more_list.dart';
 import 'package:moa_app/constants/app_constants.dart';
 import 'package:moa_app/constants/file_constants.dart';
 import 'package:moa_app/models/hashtag_model.dart';
-import 'package:moa_app/screens/home/content_view.dart';
-import 'package:moa_app/screens/home/hashtag_detail_view.dart';
 import 'package:moa_app/screens/home/home.dart';
 import 'package:moa_app/screens/home/widgets/hashtag_card.dart';
 import 'package:moa_app/screens/home/widgets/type_header.dart';
@@ -26,19 +24,15 @@ class HashtagTabView extends HookWidget {
   Widget build(BuildContext context) {
     var width = MediaQuery.of(context).size.width;
 
-    void goContentView(int contentId) {
-      context.push(
+    void goContentView(String contentId) {
+      context.go(
         '${GoRoutes.content.fullPath}/$contentId',
-        extra: ContentView(
-          contentId: contentId,
-        ),
       );
     }
 
     void goHashtagDetailView(String tag) {
-      context.push(
-        '${GoRoutes.hashtagDetail.fullPath}/$tag',
-        extra: HashtagDetailView(filterName: tag),
+      context.go(
+        '${GoRoutes.hashtag.fullPath}/$tag',
       );
     }
 
@@ -95,6 +89,7 @@ class HashtagTabView extends HookWidget {
                   extendedListDelegate:
                       SliverWaterfallFlowDelegateWithFixedCrossAxisCount(
                     crossAxisCount: width > Breakpoints.md ? 3 : 2,
+                    // crossAxisCount: 2,
                     mainAxisSpacing: 20.0,
                     crossAxisSpacing: 12.0,
                   ),
@@ -107,7 +102,7 @@ class HashtagTabView extends HookWidget {
                     return AspectRatio(
                       aspectRatio: 0.7,
                       child: HashtagCard(
-                        onPressContent: () => goContentView(5),
+                        onPressContent: () => goContentView('5'),
                         hashtag: item,
                         onPressHashtag: (tag) => goHashtagDetailView(tag),
                       ),

--- a/lib/screens/setting/edit_my_type_view.dart
+++ b/lib/screens/setting/edit_my_type_view.dart
@@ -6,14 +6,13 @@ import 'package:moa_app/constants/app_constants.dart';
 import 'package:moa_app/constants/color_constants.dart';
 import 'package:moa_app/constants/file_constants.dart';
 import 'package:moa_app/models/folder_model.dart';
-import 'package:moa_app/screens/home/folder_detail_view.dart';
 import 'package:moa_app/screens/home/home.dart';
 import 'package:moa_app/utils/general.dart';
 import 'package:moa_app/utils/router_provider.dart';
 import 'package:moa_app/widgets/app_bar.dart';
-import 'package:moa_app/widgets/dynamic_grid_list.dart';
 import 'package:moa_app/widgets/folder_list.dart';
 import 'package:moa_app/widgets/moa_widgets/add_folder.dart';
+import 'package:moa_app/widgets/moa_widgets/dynamic_grid_list.dart';
 
 class EditMyTypeView extends HookWidget {
   const EditMyTypeView({super.key});
@@ -25,10 +24,10 @@ class EditMyTypeView extends HookWidget {
     var tabIdx = useState(0);
 
     List<FolderModel> folderList = [
-      const FolderModel(id: 0, title: 'title', content: 'content'),
-      const FolderModel(id: 0, title: 'title2', content: 'content2'),
-      const FolderModel(id: 0, title: 'title3', content: 'content3'),
-      const FolderModel(id: 0, title: 'title4', content: 'content4'),
+      const FolderModel(id: '0', title: 'title', content: 'content'),
+      const FolderModel(id: '0', title: 'title2', content: 'content2'),
+      const FolderModel(id: '0', title: 'title3', content: 'content3'),
+      const FolderModel(id: '0', title: 'title4', content: 'content4'),
     ];
 
     Future<void> folderPullToRefresh() async {
@@ -53,10 +52,9 @@ class EditMyTypeView extends HookWidget {
       );
     }
 
-    void goFolderDetailView(String title) {
+    void goFolderDetailView(String id) {
       context.push(
-        '${GoRoutes.folderDetail.fullPath}/$title',
-        extra: FolderDetailView(folderName: title),
+        '${GoRoutes.folder.fullPath}/$id',
       );
     }
 
@@ -122,7 +120,7 @@ class EditMyTypeView extends HookWidget {
                         : FolderList(
                             folder: item,
                             folderColor: folderColors[index % 4],
-                            onPress: () => goFolderDetailView(item.title),
+                            onPress: () => goFolderDetailView(item.id),
                           );
                   },
                 ),

--- a/lib/screens/setting/setting.dart
+++ b/lib/screens/setting/setting.dart
@@ -17,7 +17,7 @@ class Setting extends HookConsumerWidget {
     void pickImage() {}
 
     void goEditMyType() {
-      context.push(GoRoutes.editMyType.fullPath);
+      context.go('${GoRoutes.setting.fullPath}/${GoRoutes.editContent.path}');
     }
 
     void handleContact() {}

--- a/lib/widgets/moa_widgets/dynamic_grid_list.dart
+++ b/lib/widgets/moa_widgets/dynamic_grid_list.dart
@@ -4,7 +4,6 @@ import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:go_router/go_router.dart';
 import 'package:moa_app/constants/app_constants.dart';
 import 'package:moa_app/models/hashtag_model.dart';
-import 'package:moa_app/screens/home/content_view.dart';
 import 'package:moa_app/screens/home/widgets/hashtag_card.dart';
 import 'package:moa_app/utils/router_provider.dart';
 
@@ -15,12 +14,9 @@ class DynamicGridList extends HookWidget {
   @override
   Widget build(BuildContext context) {
     var width = MediaQuery.of(context).size.width;
-    void goContentView(int contentId) {
+    void goContentView(String contentId) {
       context.push(
         '${GoRoutes.content.fullPath}/$contentId',
-        extra: ContentView(
-          contentId: contentId,
-        ),
       );
     }
 
@@ -38,7 +34,7 @@ class DynamicGridList extends HookWidget {
               crossAxisCellCount: 1,
               mainAxisCellCount: 1.4,
               child: HashtagCard(
-                onPressContent: () => goContentView(0),
+                onPressContent: () => goContentView('0'),
                 onPressHashtag: (tag) {},
                 hashtag: HashtagModel(
                   title: 'title',
@@ -51,7 +47,7 @@ class DynamicGridList extends HookWidget {
               crossAxisCellCount: 1,
               mainAxisCellCount: 1.9,
               child: HashtagCard(
-                onPressContent: () => goContentView(1),
+                onPressContent: () => goContentView('1'),
                 onPressHashtag: (tag) {},
                 hashtag: HashtagModel(
                   title: 'title',
@@ -64,7 +60,7 @@ class DynamicGridList extends HookWidget {
               crossAxisCellCount: 1,
               mainAxisCellCount: 1.9,
               child: HashtagCard(
-                onPressContent: () => goContentView(2),
+                onPressContent: () => goContentView('2'),
                 onPressHashtag: (tag) {},
                 hashtag: HashtagModel(
                   title: 'title',
@@ -77,7 +73,7 @@ class DynamicGridList extends HookWidget {
               crossAxisCellCount: 1,
               mainAxisCellCount: 1,
               child: HashtagCard(
-                onPressContent: () => goContentView(3),
+                onPressContent: () => goContentView('3'),
                 onPressHashtag: (tag) {},
                 hashtag: HashtagModel(
                   title: 'title',
@@ -90,7 +86,7 @@ class DynamicGridList extends HookWidget {
               crossAxisCellCount: 1,
               mainAxisCellCount: 1.4,
               child: HashtagCard(
-                onPressContent: () => goContentView(4),
+                onPressContent: () => goContentView('4'),
                 onPressHashtag: (tag) {},
                 hashtag: HashtagModel(
                   title: 'title',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -662,10 +662,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "00d1b67d6e9fa443331da229084dd3eb04407f5a2dff22940bd7bba6af5722c3"
+      sha256: "1531542666c2d052c44bbf6e2b48011bf3771da0404b94c60eabec1228a62906"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.1"
+    version: "9.0.0"
   google_identity_services_web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   json_annotation: ^4.8.1
   image_picker: ^0.8.6
   shared_preferences: ^2.0.15
-  go_router: ^7.1.1
+  go_router: ^9.0.0
   flutter_hooks: ^0.18.5+1
   hooks_riverpod: ^2.3.6
   sqflite: ^2.2.4+1


### PR DESCRIPTION
## 설명

`go_router` 버전을 최신 버전인 `9.0.0` 으로 업데이트 합니다
가장큰 변경점은 `context.push` 시 더이상 `url` 이 변경되지 않습니다 `context.go` 를 사용해서만 url을 변경할 수 있고 이제 `context.go` 를 사용해도 스택이 쌓이지는 않지만 뒤로가기 버튼이 동작합니다

Closes #36 
앱에서 토큰 로딩 처리때문에 발생 됐던 이슈여서 웹에서는 동작하지 않도록 처리합니다

폴더 공유하기는 `folder/$folderId` 식으로 공유됩니다