### PR TITLE
feat:외부에서 공유 url 받아오기

### DIFF
--- a/lib/models/content_model.dart
+++ b/lib/models/content_model.dart
@@ -10,6 +10,7 @@ class ContentModel with _$ContentModel {
   factory ContentModel({
     required String contentId,
     required String contentImageUrl,
+    String? contentUrl,
     String? contentMemo,
     required String contentName,
     required List<HashtagModel> contentHashTag,

--- a/lib/navigations/main_bottom_tab.dart
+++ b/lib/navigations/main_bottom_tab.dart
@@ -95,7 +95,7 @@ class MainBottomTab extends HookConsumerWidget {
       /// 외부에서 url 공유로 들어왔을경우 폴더선택화면으로 이동
       if (receiveUrl.value.isNotEmpty &&
           lifeCycle == AppLifecycleState.resumed) {
-        context.push(
+        context.go(
           GoRoutes.folderSelect.fullPath,
           extra: FolderSelect(receiveUrl: receiveUrl.value),
         );

--- a/lib/navigations/main_bottom_tab.dart
+++ b/lib/navigations/main_bottom_tab.dart
@@ -1,19 +1,109 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:moa_app/constants/app_constants.dart';
 import 'package:moa_app/constants/color_constants.dart';
 import 'package:moa_app/constants/file_constants.dart';
+import 'package:moa_app/screens/add_content/folder_select.dart';
 import 'package:moa_app/utils/my_platform.dart';
 import 'package:moa_app/utils/router_provider.dart';
+import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 
-class MainBottomTab extends HookWidget {
+class MainBottomTab extends HookConsumerWidget {
   const MainBottomTab({super.key, required this.child});
   final Widget child;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     var currentIndex = useState(0);
     bool keyboardIsOpen = MediaQuery.of(context).viewInsets.bottom == 0;
+    var lifeCycle = useAppLifecycleState();
+
+    void navigateToShareMedia(
+        BuildContext context, List<SharedMediaFile> value) {
+      if (value.isNotEmpty) {
+        var newFiles = <File>[];
+        for (var element in value) {
+          newFiles.add(File(
+            Platform.isIOS
+                ? element.type == SharedMediaType.FILE
+                    ? element.path
+                        .toString()
+                        .replaceAll(AppConstants.replaceableText, '')
+                    : element.path
+                : element.path,
+          ));
+        }
+
+        context.push(
+          '${GoRoutes.fileSharing.fullPath}/$newFiles',
+        );
+      }
+    }
+
+    var receiveUrl = useState('');
+
+    void navigateToShareText(BuildContext context, String? value) {
+      if (value != null && value.toString().isNotEmpty && context.mounted) {
+        receiveUrl.value = value;
+      }
+    }
+
+    //All listeners to listen Sharing media files & text
+    void listenShareMediaFiles(BuildContext context) {
+      // For sharing images coming from outside the app
+      // while the app is in the memory
+      ReceiveSharingIntent.getMediaStream().listen((value) {
+        navigateToShareMedia(context, value);
+      }, onError: (err) {
+        debugPrint('$err');
+      });
+
+      // For sharing images coming from outside the app while the app is closed
+      ReceiveSharingIntent.getInitialMedia().then((value) {
+        navigateToShareMedia(context, value);
+      });
+
+      // For sharing or opening urls/text coming from outside the app while the app is in the memory
+      ReceiveSharingIntent.getTextStream().listen((value) {
+        navigateToShareText(context, value);
+      }, onError: (err) {
+        debugPrint('$err');
+      });
+
+      // For sharing or opening urls/text coming from outside the app while the app is closed
+      ReceiveSharingIntent.getInitialText().then((value) {
+        navigateToShareText(context, value);
+      });
+    }
+
+    useEffect(() {
+      if (!kIsWeb) {
+        SchedulerBinding.instance.addPostFrameCallback((timeStamp) {
+          listenShareMediaFiles(context);
+        });
+      }
+      return null;
+    }, []);
+
+    useEffect(() {
+      /// 외부에서 url 공유로 들어왔을경우 폴더선택화면으로 이동
+      if (receiveUrl.value.isNotEmpty &&
+          lifeCycle == AppLifecycleState.resumed) {
+        context.push(
+          GoRoutes.folderSelect.fullPath,
+          extra: FolderSelect(receiveUrl: receiveUrl.value),
+        );
+        receiveUrl.value = '';
+        return;
+      }
+      return null;
+    }, [lifeCycle]);
 
     void tap(BuildContext context, int index) {
       if (index == currentIndex.value) {

--- a/lib/providers/folder_view_provider.dart
+++ b/lib/providers/folder_view_provider.dart
@@ -1,14 +1,15 @@
 import 'dart:async';
 
 import 'package:moa_app/models/folder_model.dart';
+import 'package:moa_app/repositories/folder_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part 'item_provider.g.dart';
+part 'folder_view_provider.g.dart';
 
 /// AsyncNotifierProvider
 // @Riverpod(keepAlive: true)
 @riverpod
-class AsyncItems extends _$AsyncItems {
+class FolderView extends _$FolderView {
   Future<List<FolderModel>> fetchItem() async {
     // get the [KeepAliveLink]
     var link = ref.keepAlive();
@@ -32,45 +33,12 @@ class AsyncItems extends _$AsyncItems {
       timer?.cancel();
     });
 
-    // var itemData = ItemRepository.instance.getItems();
-    return [];
+    var data = FolderRepository.instance.getFolderList();
+    return data;
   }
 
   @override
   Future<List<FolderModel>> build() async {
     return fetchItem();
-  }
-
-  Future<void> addItems({
-    required FolderModel item,
-  }) async {
-    state = const AsyncValue.loading();
-
-    state = await AsyncValue.guard(() async {
-      // await ItemRepository.instance.addItem(item: item);
-      return fetchItem();
-    });
-  }
-
-  Future<void> removeItems({
-    required int id,
-  }) async {
-    state = const AsyncValue.loading();
-
-    state = await AsyncValue.guard(() async {
-      // await ItemRepository.instance.removeItem(id: id);
-      return fetchItem();
-    });
-  }
-
-  Future<void> updateItems({
-    required FolderModel item,
-  }) async {
-    state = const AsyncValue.loading();
-
-    state = await AsyncValue.guard(() async {
-      // await ItemRepository.instance.updateItem(item: item);
-      return fetchItem();
-    });
   }
 }

--- a/lib/providers/hashtag_view_provider.dart
+++ b/lib/providers/hashtag_view_provider.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:moa_app/models/content_model.dart';
+import 'package:moa_app/repositories/hashtag_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'hashtag_view_provider.g.dart';
+
+/// AsyncNotifierProvider
+// @Riverpod(keepAlive: true)
+@riverpod
+class HashtagView extends _$HashtagView {
+  Future<(List<ContentModel>, int)> fetchItem() async {
+    // get the [KeepAliveLink]
+    var link = ref.keepAlive();
+    // a timer to be used by the callbacks below
+    Timer? timer;
+    // An object from package:dio that allows cancelling http requests
+    // When the provider is destroyed, cancel the http request and the timer
+    ref.onDispose(() {
+      timer?.cancel();
+    });
+    // When the last listener is removed, start a timer to dispose the cached data
+    ref.onCancel(() {
+      // start a 30 second timer
+      timer = Timer(const Duration(seconds: 30), () {
+        // dispose on timeout
+        link.close();
+      });
+    });
+    // If the provider is listened again after it was paused, cancel the timer
+    ref.onResume(() {
+      timer?.cancel();
+    });
+
+    var data = HashtagRepository.instance.getHashtagView();
+    return data;
+  }
+
+  @override
+  Future<(List<ContentModel>, int)> build() async {
+    return fetchItem();
+  }
+}

--- a/lib/repositories/content_repository.dart
+++ b/lib/repositories/content_repository.dart
@@ -26,6 +26,7 @@ class ContentRepository implements IContentRepository {
     var token = await TokenRepository.instance.getToken();
 
     if (contentType.name == AddContentType.image.name) {
+      /// 이미지 방식
       await dio.post(
         '/api/v1/content/create',
         data: {
@@ -47,6 +48,24 @@ class ContentRepository implements IContentRepository {
 
     if (contentType.name == AddContentType.url.name) {
       /// 링크 방식
+      await dio.post(
+        '/api/v1/content/create',
+        data: {
+          'folderId': content.contentId,
+          'name': content.contentName,
+          'memo': content.contentMemo,
+          'hashTag': hashTagStringList,
+          'contentType': 'URL',
+          'url': content.contentUrl,
+          // 'originalFileName': '${content.contentName}.png',
+          // 'image': 'image/png:base64:${content.contentImageUrl}',
+        },
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $token',
+          },
+        ),
+      );
     }
   }
 }

--- a/lib/repositories/hashtag_repository.dart
+++ b/lib/repositories/hashtag_repository.dart
@@ -26,6 +26,7 @@ class HashtagRepository implements IHashtagRepository {
       ),
     );
 
+    print('res.data:${res.data}');
     return (
       res.data['data']
           .map<ContentModel>((e) => ContentModel.fromJson(e))

--- a/lib/repositories/hashtag_repository.dart
+++ b/lib/repositories/hashtag_repository.dart
@@ -26,7 +26,6 @@ class HashtagRepository implements IHashtagRepository {
       ),
     );
 
-    print('res.data:${res.data}');
     return (
       res.data['data']
           .map<ContentModel>((e) => ContentModel.fromJson(e))

--- a/lib/screens/add_content/folder_select.dart
+++ b/lib/screens/add_content/folder_select.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:moa_app/constants/app_constants.dart';
 import 'package:moa_app/constants/file_constants.dart';
 import 'package:moa_app/constants/font_constants.dart';
@@ -13,11 +13,12 @@ import 'package:moa_app/widgets/alert_dialog.dart';
 import 'package:moa_app/widgets/app_bar.dart';
 import 'package:moa_app/widgets/loading_indicator.dart';
 
-class FolderSelect extends HookWidget {
-  const FolderSelect({super.key});
+class FolderSelect extends HookConsumerWidget {
+  const FolderSelect({super.key, this.receiveUrl});
+  final String? receiveUrl;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     void selectFolder({required int index, required String folderId}) {
       alertDialog.select(
         context,

--- a/lib/screens/add_content/folder_select.dart
+++ b/lib/screens/add_content/folder_select.dart
@@ -20,6 +20,16 @@ class FolderSelect extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     void selectFolder({required int index, required String folderId}) {
+      if (receiveUrl != null) {
+        context.push(
+          '${GoRoutes.folderSelect.fullPath}/${GoRoutes.addLinkContent.path}',
+          extra: AddLinkContent(
+            folderId: folderId,
+            receiveUrl: receiveUrl,
+          ),
+        );
+        return;
+      }
       alertDialog.select(
         context,
         title: '어떤 취향으로 저장하시겠어요?',
@@ -42,9 +52,17 @@ class FolderSelect extends HookConsumerWidget {
     }
 
     return Scaffold(
-      appBar: const AppBarBack(
+      appBar: AppBarBack(
         isBottomBorderDisplayed: false,
         title: '폴더 선택',
+        onPressedBack: () {
+          /// 외부 공유url 받아서 들어온 경우 뒤로가기가 안되기 떄문에 홈으로 이동
+          if (receiveUrl != null) {
+            context.go('/');
+            return;
+          }
+          context.pop();
+        },
       ),
       body: SafeArea(
         child: Padding(

--- a/lib/screens/add_content/widgets/add_content_bottom.dart
+++ b/lib/screens/add_content/widgets/add_content_bottom.dart
@@ -21,6 +21,8 @@ class AddContentBottom extends HookWidget {
     required this.tagError,
     required this.onChangedMemo,
     required this.memo,
+    this.titleController,
+    this.memoController,
   });
   final ValueChanged<String> onChangedTitle;
   final ValueNotifier<String> titleError;
@@ -32,6 +34,8 @@ class AddContentBottom extends HookWidget {
   final ValueNotifier<String> tagError;
   final ValueChanged<String> onChangedMemo;
   final ValueNotifier<String> memo;
+  final TextEditingController? titleController;
+  final TextEditingController? memoController;
 
   @override
   Widget build(BuildContext context) {
@@ -45,6 +49,7 @@ class AddContentBottom extends HookWidget {
         ),
         const SizedBox(height: 5),
         EditText(
+          controller: titleController,
           maxLength: 30,
           onChanged: onChangedTitle,
           hintText: '1~30자로 입력할 수 있어요.',
@@ -161,6 +166,7 @@ class AddContentBottom extends HookWidget {
         Stack(
           children: [
             EditText(
+              controller: memoController,
               maxLines: 4,
               maxLength: 100,
               height: 135,

--- a/lib/utils/router_provider.dart
+++ b/lib/utils/router_provider.dart
@@ -129,15 +129,9 @@ final routeProvider = Provider(
           return GoRoutes.greeting.fullPath;
         }
         var token = ref.read(tokenStateProvider);
-        if (token.value != null) {
-          var user = await UserRepository.instance.getUser();
 
-          /// 닉네임 설정 안했으면 닉네임 설정 페이지로
-          if (user?.nickname == null) {
-            return GoRoutes.inputName.fullPath;
-          }
-        }
-        if (token.value == null &&
+        var user = await UserRepository.instance.getUser();
+        if ((token.value == null || user?.nickname == null) &&
             state.matchedLocation != GoRoutes.signIn.fullPath) {
           return GoRoutes.signIn.fullPath;
         }
@@ -258,11 +252,16 @@ final routeProvider = Provider(
             parentNavigatorKey: _rootNavigatorKey,
             name: GoRoutes.folderSelect.name,
             path: GoRoutes.folderSelect.fullPath,
-            pageBuilder: (context, state) => buildIosPageTransitions<void>(
-                  context: context,
-                  state: state,
-                  child: const FolderSelect(),
+            pageBuilder: (context, state) {
+              var folderSelect = state.extra as FolderSelect;
+              return buildIosPageTransitions<void>(
+                context: context,
+                state: state,
+                child: FolderSelect(
+                  receiveUrl: folderSelect.receiveUrl,
                 ),
+              );
+            },
             routes: [
               GoRoute(
                   parentNavigatorKey: _rootNavigatorKey,

--- a/lib/utils/router_provider.dart
+++ b/lib/utils/router_provider.dart
@@ -253,13 +253,20 @@ final routeProvider = Provider(
             name: GoRoutes.folderSelect.name,
             path: GoRoutes.folderSelect.fullPath,
             pageBuilder: (context, state) {
-              var folderSelect = state.extra as FolderSelect;
+              if (state.extra != null) {
+                var folderSelect = state.extra as FolderSelect;
+                return buildIosPageTransitions<void>(
+                  context: context,
+                  state: state,
+                  child: FolderSelect(
+                    receiveUrl: folderSelect.receiveUrl,
+                  ),
+                );
+              }
               return buildIosPageTransitions<void>(
                 context: context,
                 state: state,
-                child: FolderSelect(
-                  receiveUrl: folderSelect.receiveUrl,
-                ),
+                child: const FolderSelect(),
               );
             },
             routes: [
@@ -288,6 +295,7 @@ final routeProvider = Provider(
                     state: state,
                     child: AddLinkContent(
                       folderId: addLink.folderId,
+                      receiveUrl: addLink.receiveUrl,
                     ),
                   );
                 },

--- a/lib/widgets/app_bar.dart
+++ b/lib/widgets/app_bar.dart
@@ -13,12 +13,14 @@ class AppBarBack extends StatelessWidget implements PreferredSizeWidget {
     this.actions,
     this.isBottomBorderDisplayed = true,
     this.bottomBorderStyle = const BottomBorderStyle(),
+    this.onPressedBack,
   }) : super(key: key);
   final String? title;
   final Widget? leading;
   final List<Widget>? actions;
   final bool isBottomBorderDisplayed;
   final BottomBorderStyle bottomBorderStyle;
+  final VoidCallback? onPressedBack;
 
   @override
   Widget build(BuildContext context) {
@@ -36,6 +38,10 @@ class AppBarBack extends StatelessWidget implements PreferredSizeWidget {
           image: Assets.arrowBack,
         ),
         onPressed: () {
+          if (onPressedBack != null) {
+            onPressedBack!();
+            return;
+          }
           context.pop();
         },
       ),


### PR DESCRIPTION
## 설명

외부에서 공유 url을 받아와 폴더 선택화면으로 넘겨줍니다
`main_bottom_tab.dart` 에서 `SchedulerBinding.instance.addPostFrameCallback` 을 통해 외부 에서 공유한 url을 받아오고 `folderSelect` 화면으로 `url`과 함께 넘겨줍니다

공유로 받아온 `url`의 취향을 링크 형태로만 생성되기 때문에 폴더를 선택하면 바로 링크 추가 화면으로 넘어가고 `url`을 크롤링해서 기본 정보를 보여줍니다

## 데모
![Simulator Screen Recording - iPhone 14 - 2023-07-29 at 21 58 41](https://github.com/bsideproject/moa-app/assets/73378472/83669de8-a3d4-45fc-a9a0-7346d7bb52c2)

## 기타

Closes #18 
외부 에서 바텀시트 형태의 앱을 띄워주는방법이 제한되기 떄문에 해당 pr을 닫고 지금 작성된 pr과 대체합니다