### PR TITLE
Feat/hash view loadmore

### DIFF
--- a/lib/providers/hashtag_provider.dart
+++ b/lib/providers/hashtag_provider.dart
@@ -26,7 +26,6 @@ class Hashtag extends _$Hashtag {
     state = const AsyncValue.loading();
 
     state = await AsyncValue.guard(() async {
-      // await ItemRepository.instance.addItem(item: item);
       var data = await fetchItem();
       return [hashtag, ...data];
     });

--- a/lib/providers/hashtag_view_provider.dart
+++ b/lib/providers/hashtag_view_provider.dart
@@ -33,12 +33,27 @@ class HashtagView extends _$HashtagView {
       timer?.cancel();
     });
 
-    var data = HashtagRepository.instance.getHashtagView();
+    var data = await HashtagRepository.instance.getHashtagView();
     return data;
   }
 
   @override
   Future<(List<ContentModel>, int)> build() async {
     return fetchItem();
+  }
+
+  Future<(List<ContentModel>, int)> loadMoreData({
+    int? page,
+    int? size,
+  }) async {
+    state = const AsyncValue.loading();
+
+    state = await AsyncValue.guard(() async {
+      var data = await HashtagRepository.instance
+          .getHashtagView(page: page, size: size);
+      return data;
+    });
+
+    return state.value!;
   }
 }

--- a/lib/repositories/hashtag_repository.dart
+++ b/lib/repositories/hashtag_repository.dart
@@ -5,7 +5,10 @@ import 'package:moa_app/repositories/token_repository.dart';
 import 'package:moa_app/utils/api.dart';
 
 abstract class IHashtagRepository {
-  Future<(List<ContentModel>, int)> getHashtagView();
+  Future<(List<ContentModel>, int)> getHashtagView({
+    int? page,
+    int? size,
+  });
   Future<List<HashtagModel>> getHashtagList();
 }
 
@@ -14,11 +17,14 @@ class HashtagRepository implements IHashtagRepository {
   static HashtagRepository instance = const HashtagRepository._();
 
   @override
-  Future<(List<ContentModel>, int)> getHashtagView() async {
+  Future<(List<ContentModel>, int)> getHashtagView({
+    int? page = 0,
+    int? size = 10,
+  }) async {
     var token = await TokenRepository.instance.getToken();
 
     var res = await dio.get(
-      '/api/v1/hashtag/view',
+      '/api/v1/hashtag/view?page=$page&size=$size',
       options: Options(
         headers: {
           'Authorization': 'Bearer $token',
@@ -26,9 +32,19 @@ class HashtagRepository implements IHashtagRepository {
       ),
     );
 
+    /// 백엔드 ContentModel 타입이 통일되지 않았으므로 임시로 타입 변환해서 넣어줌
     return (
       res.data['data']
-          .map<ContentModel>((e) => ContentModel.fromJson(e))
+          .map<ContentModel>(
+            (e) => ContentModel.fromJson({
+              'contentId': e['contentId'],
+              'contentImageUrl': e['imageUrl'],
+              'contentUrl': e['contentUrl'] ?? '',
+              'contentMemo': e['memo'],
+              'contentName': e['name'],
+              'contentHashTag': e['hashTags'],
+            }),
+          )
           .toList() as List<ContentModel>,
       res.data['count'] as int
     );

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -348,19 +348,25 @@ class HashtagSource extends LoadingMoreBase<ContentModel> {
     bool isSuccess = false;
 
     try {
-      var (list, _) = await HashtagRepository.instance
-          .getHashtagView(page: pageIndex, size: 10);
-      if (contentList.length < 10) {
-        var (_, count) = await futureList.future;
+      if (pageIndex == 0) {
+        var (initialList, count) = await futureList.future;
+        // 최초렌더시 컨텐츠 전체 개수 가져오기
         contentCount.value = count;
+
+        contentList.addAll(initialList);
+      } else {
+        var (list, _) = await HashtagRepository.instance
+            .getHashtagView(page: pageIndex, size: size);
+        contentList.addAll(list);
+        _hasMore = list.length >= 10;
       }
-      contentList.addAll(list);
+
       for (ContentModel content in contentList) {
         if (!contains(content) && _hasMore) {
           add(content);
         }
       }
-      _hasMore = list.length >= 10;
+
       pageIndex++;
       isSuccess = true;
     } catch (e) {

--- a/lib/screens/home/widgets/content_card.dart
+++ b/lib/screens/home/widgets/content_card.dart
@@ -30,17 +30,19 @@ class ContentCard extends HookWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Expanded(
-              child: Container(
-                width: double.infinity,
-                decoration: BoxDecoration(
-                  border: Border.all(color: AppColors.moaOpacity30),
-                  borderRadius: BorderRadius.circular(10),
-                  image: DecorationImage(
-                    image: NetworkImage(content.contentImageUrl),
-                    fit: BoxFit.contain,
-                  ),
-                ),
-              ),
+              child: content.contentImageUrl == ''
+                  ? const Text('이미지 없을 경우 모아 이미지로 대체')
+                  : Container(
+                      width: double.infinity,
+                      decoration: BoxDecoration(
+                        border: Border.all(color: AppColors.moaOpacity30),
+                        borderRadius: BorderRadius.circular(10),
+                        image: DecorationImage(
+                          image: NetworkImage(content.contentImageUrl),
+                          fit: BoxFit.contain,
+                        ),
+                      ),
+                    ),
             ),
             const SizedBox(height: 10),
             Text(

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -12,6 +12,9 @@ Future<String> xFileToBase64(XFile xFile) async {
 }
 
 Future<num> getImageSize({required String imageURL}) async {
+  if (imageURL == '') {
+    return 1.4;
+  }
   Image image = Image.network(imageURL);
   Completer<ui.Image> completer = Completer<ui.Image>();
   image.image.resolve(const ImageConfiguration()).addListener(
@@ -24,7 +27,7 @@ Future<num> getImageSize({required String imageURL}) async {
       ? 1.9
       : imageRate < 1.2
           ? 1.2
-          : imageRate;
+          : 1.4;
 }
 
 bool isStringEncoded(String value) {

--- a/lib/widgets/moa_widgets/dynamic_grid_list.dart
+++ b/lib/widgets/moa_widgets/dynamic_grid_list.dart
@@ -5,7 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:moa_app/constants/app_constants.dart';
 import 'package:moa_app/models/content_model.dart';
 import 'package:moa_app/screens/home/content_view.dart';
-import 'package:moa_app/screens/home/widgets/hashtag_card.dart';
+import 'package:moa_app/screens/home/widgets/content_card.dart';
 import 'package:moa_app/utils/router_provider.dart';
 import 'package:moa_app/utils/utils.dart';
 
@@ -35,7 +35,7 @@ class DynamicGridList extends HookWidget {
       child: SingleChildScrollView(
         padding: const EdgeInsets.only(bottom: kBottomNavigationBarHeight),
         child: StaggeredGrid.count(
-          axisDirection: AxisDirection.down, // <----- Add this line
+          axisDirection: AxisDirection.down,
           crossAxisCount: width > Breakpoints.md ? 3 : 2,
           crossAxisSpacing: 10,
           mainAxisSpacing: 20,


### PR DESCRIPTION
## 설명

해시태그 뷰 `임시 타입 설정` 및 `페이지네이션` 기능을 추가합니다
컨텐츠 상세의 컨텐츠 타입과 마찬가지로 해시태그뷰 백엔드 데이터의 모델이 통일되어있지 않으므로 임시로 프론트에서 수정해서 사용합니다

`페이지네이션`은 최초 10개를 부르고 바닥에 닿았을경우 10개씩 추가로 불러옵니다
또한 스크롤을 아래로 당겼을경우 새로고침 됩니다

## 데모

![Simulator Screen Recording - iPhone 14 - 2023-08-01 at 20 15 57](https://github.com/bsideproject/moa-app/assets/73378472/318fbb62-b2a4-4469-924c-222c6ed8da66)

## 기타

컨텐츠에 이미지 없을 경우 기본 모아 이미지가 확정되면 적용할 예정입니다