### PR TITLE
fix: 바텀네비게이션바 높이 조정

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -16,7 +15,6 @@ import 'package:moa_app/utils/config.dart';
 import 'package:moa_app/utils/custom_scaffold.dart';
 import 'package:moa_app/utils/router_provider.dart';
 import 'package:moa_app/utils/themes.dart';
-import 'package:moa_app/utils/tools.dart';
 
 class Logger extends ProviderObserver {
   @override
@@ -37,10 +35,10 @@ class Logger extends ProviderObserver {
   }
 }
 
-Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  await Firebase.initializeApp();
-  logger.d('Handling a background message: ${message.messageId}');
-}
+// Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+//   await Firebase.initializeApp();
+//   logger.d('Handling a background message: ${message.messageId}');
+// }
 
 void main() async {
   usePathUrlStrategy();
@@ -52,7 +50,7 @@ void main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
 
-  FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
+  // FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
 
   // KaKao login setup
   KakaoSdk.init(
@@ -90,6 +88,7 @@ class MyApp extends HookConsumerWidget {
         darkTheme: Themes.dark,
         themeMode: ThemeMode.light,
         routerConfig: ref.watch(routeProvider),
+        // 웹에서 scaffold를 사용할 때 최대 너비를 제한하기 위해 사용
         builder: (context, child) {
           return CustomScaffold.responsive(
             builder: (context, x, y) {

--- a/lib/navigations/main_bottom_tab.dart
+++ b/lib/navigations/main_bottom_tab.dart
@@ -122,6 +122,7 @@ class MainBottomTab extends HookConsumerWidget {
     }
 
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: child,
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButtonAnimator: FloatingActionButtonAnimator.scaling,
@@ -171,6 +172,9 @@ class MainBottomTab extends HookConsumerWidget {
             ],
           ),
           child: BottomAppBar(
+            height: MediaQuery.of(context).viewInsets.bottom > 0
+                ? 0
+                : const BottomAppBar().height,
             shape: const CircularNotchedRectangle(),
             notchMargin: 5,
             padding: EdgeInsets.only(

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -43,7 +43,7 @@ class Home extends HookConsumerWidget {
           tabIdx.value = 1;
         }
       });
-      return () => tabController.dispose();
+      return () {};
     }, []);
 
     return Container(

--- a/lib/screens/home/tab_view/folder_tab_view.dart
+++ b/lib/screens/home/tab_view/folder_tab_view.dart
@@ -124,8 +124,6 @@ class FolderTabView extends HookConsumerWidget {
         {required String folderName, required Color folderColor}) {
       General.instance.showBottomSheet(
         context: context,
-        padding:
-            const EdgeInsets.only(left: 15, right: 15, top: 15, bottom: 30),
         height: 225,
         child: Column(
           children: [

--- a/lib/utils/custom_scaffold.dart
+++ b/lib/utils/custom_scaffold.dart
@@ -20,7 +20,10 @@ class CustomScaffold extends StatelessWidget {
   }
 
   static Scaffold _buildSafeScaffold({required Widget child}) {
-    return Scaffold(body: child);
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      body: child,
+    );
   }
 
   @override

--- a/lib/utils/general.dart
+++ b/lib/utils/general.dart
@@ -19,11 +19,15 @@ class General {
     showModalBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,
-      builder: (_) => isContainer
+      isScrollControlled: true,
+      builder: (context) => isContainer
           ? Container(
               height: height,
-              padding: padding ??
-                  const EdgeInsets.symmetric(horizontal: 25, vertical: 20),
+              padding: EdgeInsets.only(
+                  left: 15,
+                  right: 15,
+                  top: 20,
+                  bottom: MediaQuery.of(context).viewInsets.bottom),
               decoration: const BoxDecoration(
                 color: AppColors.whiteColor,
                 borderRadius: BorderRadius.only(
@@ -55,7 +59,22 @@ class General {
                     )
                   : child,
             )
-          : child,
+          : Container(
+              padding: EdgeInsets.only(
+                left: 15,
+                right: 15,
+                top: 50,
+                bottom: MediaQuery.of(context).viewInsets.bottom,
+              ),
+              decoration: const BoxDecoration(
+                color: AppColors.whiteColor,
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(24),
+                  topRight: Radius.circular(24),
+                ),
+              ),
+              child: child,
+            ),
       // isDismissible: false,
       enableDrag: false,
     );

--- a/lib/widgets/moa_widgets/add_folder.dart
+++ b/lib/widgets/moa_widgets/add_folder.dart
@@ -69,82 +69,70 @@ class AddFolder extends HookConsumerWidget {
       emptyFolderName();
     }
 
-    return Container(
-      decoration: const BoxDecoration(
-        color: AppColors.whiteColor,
-        borderRadius: BorderRadius.only(
-          topLeft: Radius.circular(24),
-          topRight: Radius.circular(24),
-        ),
-      ),
-      child: Stack(children: [
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 25),
-          child: Form(
-            key: formKey,
-            child: Column(
+    return Stack(children: [
+      Form(
+        key: formKey,
+        child: Column(
+          children: [
+            const Center(
+              child: Text('폴더 추가', style: H2TextStyle()),
+            ),
+            const SizedBox(height: 30),
+            EditFormText(
+              maxLength: 7,
+              controller: folderNameController,
+              onChanged: folderOnChangedValue,
+              hintText: '폴더명을 입력하세요.',
+              backgroundColor: AppColors.textInputBackground,
+              suffixIcon: CircleIconButton(
+                icon: Image(
+                  fit: BoxFit.contain,
+                  image: Assets.circleClose,
+                  width: 16,
+                  height: 16,
+                ),
+                onPressed: emptyFolderName,
+              ),
+            ),
+            const SizedBox(height: 5),
+            Row(
               children: [
-                const Center(
-                  child: Text('폴더 추가', style: H2TextStyle()),
-                ),
-                const SizedBox(height: 30),
-                EditFormText(
-                  maxLength: 7,
-                  controller: folderNameController,
-                  onChanged: folderOnChangedValue,
-                  hintText: '폴더명을 입력하세요.',
-                  backgroundColor: AppColors.textInputBackground,
-                  suffixIcon: CircleIconButton(
-                    icon: Image(
-                      fit: BoxFit.contain,
-                      image: Assets.circleClose,
-                      width: 16,
-                      height: 16,
-                    ),
-                    onPressed: emptyFolderName,
-                  ),
-                ),
-                const SizedBox(height: 5),
-                Row(
-                  children: [
-                    const Spacer(),
-                    Text(
-                      '${folderNameController.text.length}/7',
-                      style: TextStyle(
-                          color: folderNameController.text.length == 7
-                              ? AppColors.danger
-                              : AppColors.blackColor.withOpacity(0.3),
-                          fontSize: 12,
-                          fontFamily: FontConstants.pretendard),
-                    ),
-                  ],
-                ),
                 const Spacer(),
-                Button(
-                  loading: loading.value,
-                  disabled: folderNameController.text.isEmpty,
-                  margin: const EdgeInsets.only(bottom: 30),
-                  text: '추가하기',
-                  onPress: addFolder,
-                )
+                Text(
+                  '${folderNameController.text.length}/7',
+                  style: TextStyle(
+                      color: folderNameController.text.length == 7
+                          ? AppColors.danger
+                          : AppColors.blackColor.withOpacity(0.3),
+                      fontSize: 12,
+                      fontFamily: FontConstants.pretendard),
+                ),
               ],
             ),
+            const Spacer(),
+            Button(
+              loading: loading.value,
+              disabled: folderNameController.text.isEmpty,
+              margin: const EdgeInsets.only(bottom: 30),
+              text: '추가하기',
+              onPress: addFolder,
+            )
+          ],
+        ),
+      ),
+      Positioned(
+        right: -15,
+        top: -15,
+        child: CircleIconButton(
+          backgroundColor: Colors.white,
+          onPressed: closeBottomSheet,
+          icon: const Icon(
+            Icons.close,
+            color: AppColors.blackColor,
+            size: 30,
           ),
         ),
-        Positioned(
-          right: 0,
-          top: 12,
-          child: CircleIconButton(
-            backgroundColor: Colors.white,
-            onPressed: closeBottomSheet,
-            icon: const Icon(
-              Icons.close,
-              color: AppColors.blackColor,
-              size: 30,
-            ),
-          ),
-        )
-      ]),
-    );
+      )
+    ]);
   }
 }

--- a/lib/widgets/moa_widgets/edit_content.dart
+++ b/lib/widgets/moa_widgets/edit_content.dart
@@ -57,83 +57,71 @@ class EditContent extends HookWidget {
       emptyContentName();
     }
 
-    return Container(
-      decoration: const BoxDecoration(
-        color: AppColors.whiteColor,
-        borderRadius: BorderRadius.only(
-          topLeft: Radius.circular(24),
-          topRight: Radius.circular(24),
-        ),
-      ),
-      child: Stack(children: [
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 25),
-          child: Form(
-            key: formKey,
-            child: Column(
+    return Stack(children: [
+      Form(
+        key: formKey,
+        child: Column(
+          children: [
+            Center(
+              child: Text(title, style: const H2TextStyle()),
+            ),
+            const SizedBox(height: 30),
+            EditFormText(
+              maxLength: maxLength ?? 7,
+              controller: controller,
+              onChanged: onChangedContentValue,
+              hintText: contentName,
+              backgroundColor: AppColors.textInputBackground,
+              suffixIcon: CircleIconButton(
+                icon: Image(
+                  fit: BoxFit.contain,
+                  image: Assets.circleClose,
+                  width: 16,
+                  height: 16,
+                ),
+                onPressed: emptyContentName,
+              ),
+            ),
+            ErrorText(
+                errorText: errorText.value,
+                errorValidate: errorText.value != ''),
+            Row(
               children: [
-                Center(
-                  child: Text(title, style: const H2TextStyle()),
-                ),
-                const SizedBox(height: 30),
-                EditFormText(
-                  maxLength: maxLength ?? 7,
-                  controller: controller,
-                  onChanged: onChangedContentValue,
-                  hintText: contentName,
-                  backgroundColor: AppColors.textInputBackground,
-                  suffixIcon: CircleIconButton(
-                    icon: Image(
-                      fit: BoxFit.contain,
-                      image: Assets.circleClose,
-                      width: 16,
-                      height: 16,
-                    ),
-                    onPressed: emptyContentName,
-                  ),
-                ),
-                ErrorText(
-                    errorText: errorText.value,
-                    errorValidate: errorText.value != ''),
-                Row(
-                  children: [
-                    const Spacer(),
-                    Text(
-                      '${controller.text.length}/${maxLength ?? 7}',
-                      style: TextStyle(
-                          color: controller.text.length >= (maxLength ?? 7)
-                              ? AppColors.danger
-                              : AppColors.blackColor.withOpacity(0.3),
-                          fontSize: 12,
-                          fontFamily: FontConstants.pretendard),
-                    ),
-                  ],
-                ),
                 const Spacer(),
-                Button(
-                  disabled: controller.text.isEmpty,
-                  margin: const EdgeInsets.only(bottom: 30),
-                  text: buttonText ?? '수정하기',
-                  onPress: editContent,
-                )
+                Text(
+                  '${controller.text.length}/${maxLength ?? 7}',
+                  style: TextStyle(
+                      color: controller.text.length >= (maxLength ?? 7)
+                          ? AppColors.danger
+                          : AppColors.blackColor.withOpacity(0.3),
+                      fontSize: 12,
+                      fontFamily: FontConstants.pretendard),
+                ),
               ],
             ),
+            const Spacer(),
+            Button(
+              disabled: controller.text.isEmpty,
+              margin: const EdgeInsets.only(bottom: 30),
+              text: buttonText ?? '수정하기',
+              onPress: editContent,
+            )
+          ],
+        ),
+      ),
+      Positioned(
+        right: -15,
+        top: -15,
+        child: CircleIconButton(
+          backgroundColor: Colors.white,
+          onPressed: closeBottomSheet,
+          icon: const Icon(
+            Icons.close,
+            color: Colors.black,
+            size: 30,
           ),
         ),
-        Positioned(
-          right: 0,
-          top: 12,
-          child: CircleIconButton(
-            backgroundColor: Colors.white,
-            onPressed: closeBottomSheet,
-            icon: const Icon(
-              Icons.close,
-              color: Colors.black,
-              size: 30,
-            ),
-          ),
-        )
-      ]),
-    );
+      )
+    ]);
   }
 }


### PR DESCRIPTION
## 설명

바텀네비게이션바가 있을때 키보드가 올라오면 네비게이션바가 같이 올라오는 문제를 `Scaffold` 에 `resizeToAvoidBottomInset` `false` 효과를 주어서 수정합니다

또한 `showModalBottomSheet` 에서 키보드가 올라올때 바텀시트가 가려지는 문제가 있기때문에 우선적으로 `isScrollControlled` `true` 옵션을 주어서 바텀시트가 전체영역을 차지하는 방법으로 해결합니다
[참고](https://stackoverflow.com/questions/53869078/how-to-move-bottomsheet-along-with-keyboard-which-has-textfieldautofocused-is-t)

## 이슈
#54 
추후 전체영역을 차지하지않고 바텀시트가 키보드위에 올라올수 있게 적용할 예정입니다


## 데모
![Simulator Screen Recording - iPhone 14 - 2023-08-05 at 15 06 24](https://github.com/bsideproject/moa-app/assets/73378472/c7e379d8-2cb5-4df8-904b-49af8dd669c5)


